### PR TITLE
menú responsive en móviles

### DIFF
--- a/static/css/dashboard_styles.css
+++ b/static/css/dashboard_styles.css
@@ -65,26 +65,28 @@ header {
 /* Estilos: Dropdown del Usuario */
 /* ----------------------------- */
 
+
 #dropdown {
   display: none;
   position: absolute;
   right: 0;
-  top: 50%;
+  top: 100%;
+  margin-top: 0.5rem;
   background: #1A1D29; /* Mismo color que el botón */
   list-style: none;
   margin: 0;
-  padding: 1rem 3rem;
-  padding-top: 4rem;
+  padding: 1rem 3rem 2rem;
   border: none;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   border-bottom-left-radius: 30px;
   border-bottom-right-radius: 30px;
-  width: 100%; /* Igual que el botón */
+  min-width: 250px;
+  max-width: 300px;
+  width: max-content;
   box-sizing: border-box;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
   z-index: 10;
-  position: absolute;
-  right: 0;
 }
 
 #dropdown.show {
@@ -101,8 +103,8 @@ header {
   text-decoration: none;
   display: block;
   width: 100%;
-  font-weight: bold;       /* Negrita */
-  white-space: nowrap;     /* Una sola línea */
+  font-weight: bold;           /* Negrita */
+  white-space: nowrap;         /* Una sola línea */
   text-align: right;
 }
 
@@ -178,3 +180,95 @@ Agregar imagen de fondo para cuando el main esta inactivo
 }
 
 */
+
+@media (max-width: 768px) {
+  header {
+    padding: 1rem;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: nowrap;
+  }
+
+  .logo-letras {
+    height: 36px;
+    margin: 0;
+  }
+
+  .user-menu {
+    position: relative;
+    width: auto;
+  }
+
+  #user-button {
+    padding: 0.6rem 1rem;
+    font-size: 0.85rem;
+    min-width: unset;
+    max-width: 180px;
+    width: auto;
+    white-space: nowrap;
+  }
+
+  #dropdown {
+    width: 100%;
+    max-width: 180px;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    padding: 1rem 1rem;
+    background: #1A1D29;
+    border-bottom-left-radius: 20px;
+    border-bottom-right-radius: 20px;
+    box-sizing: border-box;
+    z-index: 10;
+    display: none;
+  }
+
+  #dropdown.show {
+    display: block;
+  }
+
+  .contenedor-main {
+    flex-direction: column;
+  }
+
+  .side-navbar {
+    width: 100%;
+    padding: 1rem;
+  }
+
+  .side-navbar a {
+    font-size: 1rem;
+  }
+
+  .main-dinamico {
+    padding: 1rem;
+  }
+
+  .user-menu {
+    display: inline-block;
+    width: auto;
+    max-width: 180px;
+  }
+
+  #user-button {
+    width: 100%;
+    max-width: 180px;
+  }
+
+  #dropdown {
+    width: 100%;
+    max-width: 180px;
+    min-width: unset;
+    left: 0;
+    right: 0;
+    margin: 0 auto;
+  }
+
+    #dropdown li a {
+    white-space: normal;    /* ❗ Permite saltos de línea */
+    word-wrap: break-word;  /* ❗ Rompe palabras largas si es necesario */
+    font-size: 0.85rem;     /* ❗ Opcional: letra más chica para mejor ajuste */
+    line-height: 1.2;       /* ❗ Espaciado más compacto entre líneas */
+  }
+}

--- a/static/css/home-styles.css
+++ b/static/css/home-styles.css
@@ -4,51 +4,53 @@
   padding: 0;
 }
 
-body, html {
+html, body {
   height: 100%;
   font-family: 'Inter', sans-serif;
+  overflow-x: hidden; /* Evita scroll horizontal */
 }
 
+/* ==== CONTENEDOR PRINCIPAL ==== */
 .container {
   display: flex;
-  height: 100vh;
+  flex-direction: row;
+  min-height: 100vh; /* Altura mínima total de la pantalla */
+  width: 100%;
 }
 
-/* Panel izquierdo →  logo + copy */
+/* === PANEL IZQUIERDO → logo + texto === */
 .left-panel {
-  width: 66.666%; /* 4/6 de la pantalla */
+  flex: 2; /* Ocupa 2/3 del ancho */
   background: linear-gradient(270deg, #FFFFFF 0.95%, #B1B2B5 98.3%);
   display: flex;
+  justify-content: center;
+  align-items: center;
   padding: 40px;
-  padding-left: 100px; /* espacio interno (padding) en borde izquierdo */
 }
 
 .logo-section {
   display: flex;
   flex-direction: column; /* apila verticalmente */
-  justify-content: center;
-  align-items: flex-start; /* alinea a la izquierda */
-  text-align: left;
-  padding: 40px;
-  max-width: 800px; /* ancho máximo opcional */
-}
-
-.texto-copy {
-  font-size: 25px;
-  line-height: 1.5;     /* Para que el texto sea más legible */
-  text-align: justify;  /* Para justificar el texto */
+  align-items: flex-start;
+  max-width: 800px;
 }
 
 .logo {
-
-  width: 400px;
+  width: 100%;
+  max-width: 300px; /* tamaño máximo del logo */
   height: auto;
   margin-bottom: 24px;
 }
 
-/* Panel derecho →  formulario */
+.texto-copy {
+  font-size: 22px;
+  line-height: 1.5;     /* Para que el texto sea más legible */
+  text-align: justify;  /* Para justificar el texto */
+}
+
+/* === PANEL DERECHO → formulario === */
 .right-panel {
-  width: 33.333%; /* 2/6  de la pantalla*/
+  flex: 1; /* Ocupa 1/3 del ancho */
   background-color: #1A1D29;
   display: flex;
   justify-content: center;
@@ -67,35 +69,80 @@ body, html {
 
 .login-form h2 {
   font-family: 'Questrial', sans-serif;
-  font-size: 30px;
-  margin-bottom: 16px;
+  font-size: 28px;
   text-align: center;
+  margin-bottom: 12px;
 }
 
 .login-form label {
+  font-size: 16px;
   font-weight: 600;
-  font-size: 18px;
 }
 
 .login-form input {
   padding: 10px;
   border: none;
-  border-radius: 8px;
-  font-size: 18px;
+  border-radius: 6px;
+  font-size: 16px;
 }
 
 .login-form button {
-  margin-top: 12px;
+  margin-top: 10px;
   padding: 10px;
   background-color: #C4C4C4;
   color: #000;
   border: none;
-  border-radius: 10px;
+  border-radius: 8px;
   font-weight: bold;
   cursor: pointer;
-  font-size: 18px;
+  font-size: 16px;
 }
 
 .login-form button:hover {
   background-color: #aaaaaa;
 }
+
+/* ==== MEDIA QUERY para celulares y pantallas pequeñas ==== */
+@media (max-width: 768px) {
+  .container {
+    flex-direction: column; /* Apila verticalmente */
+    min-height: 100vh;
+  }
+
+  .left-panel, .right-panel {
+    width: 100%;
+    padding: 20px;
+  }
+
+  .logo-section {
+    align-items: center;
+    text-align: center;
+  }
+
+  .logo {
+    max-width: 200px;
+  }
+
+  .texto-copy {
+    font-size: 16px;
+    padding: 0 10px;
+  }
+
+  .login-form {
+    width: 100%;
+    max-width: 100%;
+    padding: 0 10px;
+  }
+
+  .login-form input,
+  .login-form button {
+    font-size: 16px;
+  }
+}
+
+/* === PREVENCIÓN DE SCROLL VERTICAL INNECESARIO === */
+body {
+  overflow-y: auto;
+}
+
+

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -20,3 +20,17 @@ a {
 h1, h2, h3 {
   font-family: 'Questrial', sans-serif;
 }
+
+
+@media (max-width: 768px) {
+  .side-navbar {
+    width: 100% !important;  /* Ocupa todo el ancho en móviles */
+    padding-left: 1rem;
+    padding-right: 1rem;
+    box-sizing: border-box;
+  }
+
+  .side-navbar a {
+    font-size: 1rem;
+  }
+}


### PR DESCRIPTION
Se realizaron ajustes en el menú de usuario para que en dispositivos móviles:

El menú quede a la derecha del logo.

El dropdown no ocupe más ancho del necesario.

Las opciones del menú se dividan en líneas cuando tienen más de una palabra.

Las palabras largas en una sola línea reduzcan tamaño para evitar overflow.

Estos cambios buscan mejorar la usabilidad y la experiencia en pantallas pequeñas como iPhone SE.

Nota:
Este PR está listo para revisión. No se realiza el merge hasta que sea aprobado por el equipo.